### PR TITLE
BUG: Multiply versions of years in dropdown box

### DIFF
--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -16,9 +16,9 @@ def stockists(request):
         'venues': Venue.objects.all().order_by('name'),
         'exhibition_years': set(sorted(
             Stockist.objects.filter(end_date__lt=timezone.now())
-                .values_list(
-                    'end_date__year',
-                    flat=True),
+            .values_list(
+                'end_date__year',
+                flat=True),
             reverse=True
         )),
     }

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -14,13 +14,13 @@ def stockists(request):
         'past_stockists': Stockist.objects.filter(
             end_date__lt=timezone.now()).order_by('-end_date'),
         'venues': Venue.objects.all().order_by('name'),
-        'exhibition_years': sorted(
+        'exhibition_years': set(sorted(
             Stockist.objects.filter(end_date__lt=timezone.now())
                 .values_list(
                     'end_date__year',
-                    flat=True).distinct(),
+                    flat=True),
             reverse=True
-        ),
+        )),
     }
     return render(request, 'stockists.html', context)
 


### PR DESCRIPTION
Make exhibition years a set to avoid duplication of years in dropdown.

Fixes #44 