### PR TITLE
Update stockists page text and reorder stockists by start date

### DIFF
--- a/app/homepage/templates/homepage/index.html
+++ b/app/homepage/templates/homepage/index.html
@@ -25,6 +25,10 @@
             Please browse the <a href="{% url 'gallery' %}"><b>gallery</b></a> to enjoy images from the full range of my
             work.
         </p>
+        <p>
+            Please check out the <a href="{% url 'stockists' %}"><b>stockists</b></a> page to see where I will be
+            showing my work throughout the current year.
+        </p>
         <p class="potters-mark">
             <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark" class="potters-mark" />
         </p>

--- a/app/pages/templates/about.html
+++ b/app/pages/templates/about.html
@@ -10,13 +10,21 @@
                 About Lesley
             </h2>
             <p>
-                After completing an art foundation course in Scarborough I studied for a degree in 3D design / ceramics at Cardiff Art College and on completion of a postgraduate course in education I taught art in a state secondary school in Crewe, Cheshire.
+                After completing an art foundation course in Scarborough I studied for a degree in 3D design / ceramics
+                at Cardiff Art College and on completion of a postgraduate course in education I taught art in a state
+                secondary school in Crewe, Cheshire.
             </p>
             <p>
-                When my youngest child began school I began to look for an opportunity to use and develop my creative skills which would fit around the demands of family life. I applied for and was awarded a small enterprise allowance by Cheshire County Council which included helpful business advice and I was able to set up my first ceramics workshop.
+                When my youngest child began school I began to look for an opportunity to use and develop my creative
+                skills which would fit around the demands of family life. I applied for and was awarded a small
+                enterprise allowance by Cheshire County Council which included helpful business advice and I was able to
+                set up my first ceramics workshop.
             </p>
             <p>
-                Initially I began showing and selling my work to the public at a variety of local fairs and venues. Now I have gained recognition and success in exhibiting and selling through public and private art galleries as well as ceramic festivals and trade shows and I am always looking for opportunities to reach out to a fresh audience.
+                Initially I began showing and selling my work to the public at a variety of local fairs and venues. Now
+                I have gained recognition and success in exhibiting and selling through public and private art galleries
+                as well as ceramic festivals and trade shows and I am always looking for opportunities to reach out to a
+                fresh audience.
             </p>
             <a href="{% static 'documents/lagreene-ceramics-cv.pdf' %}" target="_blank">
                 <h5>
@@ -24,12 +32,12 @@
                 </h5>
             </a>
             <p class="potters-mark">
-                <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark" class="potters-mark"/>
+                <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark" class="potters-mark" />
             </p>
         </div>
     </div>
     <div class="col-md-4 about-image" id="portrait">
-        <img src="{% static_cdn 'images/portrait-with-work_sm.jpeg' %}" alt="Artist photo"> 
+        <img src="{% static_cdn 'images/portrait-with-work_sm.jpeg' %}" alt="Artist photo">
     </div>
     <div class="col-md-4 about-image">
         <img src="{% static_cdn 'images/work_in_progress_sealife_sm.jpeg' %}" alt="Artist photo">
@@ -40,20 +48,29 @@
                 Inspiration
             </h2>
             <p>
-                My subjects are mostly inspired by encounters with the animal kingdom at home and abroad and I am particularly interested in how animals and human interaction are described in folk songs and myth.
+                My subjects are mostly inspired by encounters with the animal kingdom at home and abroad and I am
+                particularly interested in how animals and human interaction are described in folk songs and myth.
             </p>
             <p>
-                It is important to me to instil character and humour in my work and I have created a unique collection of both domestic and exotic creatures since commencing my business in 1994. Every piece is a one off with its own persona demonstrating an imaginative interpretation of a particular experience or story. While some themes have been revisited and refined I continue to research and explore new topics. 
+                It is important to me to instil character and humour in my work and I have created a unique collection
+                of both domestic and exotic creatures since commencing my business in 1994. Every piece is a one off
+                with its own persona demonstrating an imaginative interpretation of a particular experience or story.
+                While some themes have been revisited and refined I continue to research and explore new topics.
             </p>
             <p>
-                I like visiting and looking at artefacts in museums and on ancient sites and some forms for earlier works were inspired by animals represented in cultural objects and in particular the tomb statuary of ancient Egypt.
-                I enjoy walking in the countryside and along the coast near to my East Yorkshire home and more recent works have been inspired by observations and reactions to the natural world, flora and fauna around me. 
+                I like visiting and looking at artefacts in museums and on ancient sites and some forms for earlier
+                works were inspired by animals represented in cultural objects and in particular the tomb statuary of
+                ancient Egypt.
+                I enjoy walking in the countryside and along the coast near to my East Yorkshire home and more recent
+                works have been inspired by observations and reactions to the natural world, flora and fauna around me.
             </p>
             <p>
-                I am currently engaged in making and experimenting with stylised tree forms each with a story to tell.
+                Recent works have included making and experimenting with stylised tree forms each with a story to tell
+                and shallow bowl forms inspired by sea life.
             </p>
             <p class="potters-mark">
-                <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark" class="potters-mark line-break-right-side"/>
+                <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark"
+                    class="potters-mark line-break-right-side" />
             </p>
         </div>
     </div>
@@ -63,23 +80,31 @@
                 Techniques
             </h2>
             <p>
-                All works are individually hand built and modelled. Using a grogged clay body for texture and strength I employ techniques including slabbing, coiling and pinching and I model detail with simple tools and my fingers.
+                All works are individually hand built and modelled. Using a grogged clay body for texture and strength I
+                employ techniques including slabbing, coiling and pinching and I model detail with simple tools and my
+                fingers.
             </p>
-            <p>   
-                The surface of the finished object is sponged to expose the texture of the clay body and other effects are achieved by using impressing, scoring and sprigging methods.
-                Colour is applied using body stains and coloured slips before biscuit firing to 1000 degrees celsius in an electric kiln. Then, prior to a higher firing of around 1185 degrees celsius, the surface texture is enhanced with a wash of metallic oxides which is sponged back and more colour is added using brush on stains and glazes.
-                A shiny transparent glaze is applied in the areas that are to be given a gold or platinum lustre finish which involves a third firing to 750 degrees celsius.
+            <p>
+                The surface of the finished object is sponged to expose the texture of the clay body and other effects
+                are achieved by using impressing, scoring and sprigging methods.
+                Colour is applied using body stains and coloured slips before biscuit firing to 1000 degrees celsius in
+                an electric kiln. Then, prior to a higher firing of around 1185 degrees celsius, the surface texture is
+                enhanced with a wash of metallic oxides which is sponged back and more colour is added using brush on
+                stains and glazes.
+                A shiny transparent glaze is applied in the areas that are to be given a gold or platinum lustre finish
+                which involves a third firing to 750 degrees celsius.
             </p>
-            <p>   
-                Ornaments using textile tassels, jewellery wire and beads are assembled and attached as a contrast to the ceramic textiles on some pieces adding a sense of movement.
+            <p>
+                Ornaments using textile tassels, jewellery wire and beads are assembled and attached as a contrast to
+                the ceramic textiles on some pieces adding a sense of movement.
             </p>
             <p class="potters-mark">
-                <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark" class="potters-mark"/>
+                <img src="{% static 'images/icons/PottersMark_white.png' %}" alt="potters mark" class="potters-mark" />
             </p>
         </div>
     </div>
     <div class="col-md-4 about-image">
-        <img src="{% static_cdn 'images/work_in_kiln_sealife_sm.jpeg' %}" alt="Artist photo"> 
+        <img src="{% static_cdn 'images/work_in_kiln_sealife_sm.jpeg' %}" alt="Artist photo">
     </div>
 </div>
 

--- a/app/pages/tests.py
+++ b/app/pages/tests.py
@@ -1,8 +1,12 @@
-from django.test import TestCase
+from datetime import timedelta
+
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.test import SimpleTestCase, override_settings
-from django.urls import path
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.urls import path, reverse
+from django.utils import timezone
+
+from pages.models import Stockist
 
 
 def response_error_handler(request, exception=None):
@@ -28,3 +32,82 @@ class CustomErrorHandlerTests(SimpleTestCase):
         response = self.client.get('/403/')
         # Make assertions on the response here. For example:
         self.assertContains(response, 'Permission denied!', status_code=403)
+
+
+@override_settings(STORAGES={
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+})
+class StockistsViewTests(TestCase):
+    def test_current_stockists_ordered_by_start_date(self):
+        """Current stockists should be ordered by start_date ascending."""
+        now = timezone.now().date()
+        future = now + timedelta(days=30)
+
+        # Create stockists with future end_dates and varying start_dates
+        stockist_late = Stockist.objects.create(
+            title='Late Start',
+            start_date=now + timedelta(days=10),
+            end_date=future,
+        )
+        stockist_early = Stockist.objects.create(
+            title='Early Start',
+            start_date=now + timedelta(days=2),
+            end_date=future,
+        )
+        stockist_mid = Stockist.objects.create(
+            title='Mid Start',
+            start_date=now + timedelta(days=5),
+            end_date=future,
+        )
+
+        response = self.client.get(reverse('stockists'))
+        current = list(response.context['current_stockists'])
+
+        self.assertEqual(current, [stockist_early, stockist_mid, stockist_late])
+
+    def test_current_stockists_null_start_date_last(self):
+        """Current stockists with null start_date should appear last."""
+        now = timezone.now().date()
+        future = now + timedelta(days=30)
+
+        stockist_with_date = Stockist.objects.create(
+            title='Has Start Date',
+            start_date=now + timedelta(days=5),
+            end_date=future,
+        )
+        stockist_null = Stockist.objects.create(
+            title='No Start Date',
+            start_date=None,
+            end_date=future,
+        )
+
+        response = self.client.get(reverse('stockists'))
+        current = list(response.context['current_stockists'])
+
+        self.assertEqual(current, [stockist_with_date, stockist_null])
+
+    def test_past_stockists_ordered_by_end_date_desc(self):
+        """Past stockists should be ordered by end_date descending."""
+        now = timezone.now().date()
+
+        stockist_oldest = Stockist.objects.create(
+            title='Oldest',
+            start_date=now - timedelta(days=60),
+            end_date=now - timedelta(days=30),
+        )
+        stockist_newest = Stockist.objects.create(
+            title='Newest',
+            start_date=now - timedelta(days=10),
+            end_date=now - timedelta(days=1),
+        )
+        stockist_middle = Stockist.objects.create(
+            title='Middle',
+            start_date=now - timedelta(days=30),
+            end_date=now - timedelta(days=15),
+        )
+
+        response = self.client.get(reverse('stockists'))
+        past = list(response.context['past_stockists'])
+
+        self.assertEqual(past, [stockist_newest, stockist_middle, stockist_oldest])

--- a/app/pages/tests.py
+++ b/app/pages/tests.py
@@ -6,7 +6,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import path, reverse
 from django.utils import timezone
 
-from pages.models import Stockist
+from pages.models import Stockist, Venue
 
 
 def response_error_handler(request, exception=None):
@@ -39,6 +39,9 @@ class CustomErrorHandlerTests(SimpleTestCase):
     "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
 })
 class StockistsViewTests(TestCase):
+    def setUp(self):
+        self.venue = Venue.objects.create(name='Test Venue')
+
     def test_current_stockists_ordered_by_start_date(self):
         """Current stockists should be ordered by start_date ascending."""
         now = timezone.now().date()
@@ -47,16 +50,19 @@ class StockistsViewTests(TestCase):
         # Create stockists with future end_dates and varying start_dates
         stockist_late = Stockist.objects.create(
             title='Late Start',
+            venue=self.venue,
             start_date=now + timedelta(days=10),
             end_date=future,
         )
         stockist_early = Stockist.objects.create(
             title='Early Start',
+            venue=self.venue,
             start_date=now + timedelta(days=2),
             end_date=future,
         )
         stockist_mid = Stockist.objects.create(
             title='Mid Start',
+            venue=self.venue,
             start_date=now + timedelta(days=5),
             end_date=future,
         )
@@ -73,11 +79,13 @@ class StockistsViewTests(TestCase):
 
         stockist_with_date = Stockist.objects.create(
             title='Has Start Date',
+            venue=self.venue,
             start_date=now + timedelta(days=5),
             end_date=future,
         )
         stockist_null = Stockist.objects.create(
             title='No Start Date',
+            venue=self.venue,
             start_date=None,
             end_date=future,
         )
@@ -93,16 +101,19 @@ class StockistsViewTests(TestCase):
 
         stockist_oldest = Stockist.objects.create(
             title='Oldest',
+            venue=self.venue,
             start_date=now - timedelta(days=60),
             end_date=now - timedelta(days=30),
         )
         stockist_newest = Stockist.objects.create(
             title='Newest',
+            venue=self.venue,
             start_date=now - timedelta(days=10),
             end_date=now - timedelta(days=1),
         )
         stockist_middle = Stockist.objects.create(
             title='Middle',
+            venue=self.venue,
             start_date=now - timedelta(days=30),
             end_date=now - timedelta(days=15),
         )

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -12,7 +12,8 @@ def about(request):
 def stockists(request):
     context = {
         'current_stockists': Stockist.objects.filter(
-            end_date__gte=timezone.now()).order_by(F('start_date').asc(nulls_last=True)),
+            end_date__gte=timezone.now()).order_by(
+                F('start_date').asc(nulls_last=True), 'pk'),
         'past_stockists': Stockist.objects.filter(
             end_date__lt=timezone.now()).order_by('-end_date'),
         'venues': Venue.objects.all().order_by('name'),

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -1,6 +1,8 @@
+from django.db.models import F
 from django.shortcuts import render
-from pages.models import Link, Stockist, Venue
 from django.utils import timezone
+
+from pages.models import Link, Stockist, Venue
 
 def about(request):
     context = {
@@ -10,7 +12,7 @@ def about(request):
 def stockists(request):
     context = {
         'current_stockists': Stockist.objects.filter(
-            end_date__gte=timezone.now()).order_by('start_date'),
+            end_date__gte=timezone.now()).order_by(F('start_date').asc(nulls_last=True)),
         'past_stockists': Stockist.objects.filter(
             end_date__lt=timezone.now()).order_by('-end_date'),
         'venues': Venue.objects.all().order_by('name'),

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -10,16 +10,17 @@ def about(request):
     return render(request, 'about.html', context)
 
 def stockists(request):
+    today = timezone.localdate()
     context = {
         'current_stockists': Stockist.objects.filter(
-            end_date__gte=timezone.now()).order_by(
+            end_date__gte=today).order_by(
                 F('start_date').asc(nulls_last=True), 'pk'),
         'past_stockists': Stockist.objects.filter(
-            end_date__lt=timezone.now()).order_by('-end_date'),
+            end_date__lt=today).order_by('-end_date'),
         'venues': Venue.objects.all().order_by('name'),
         'exhibition_years': sorted(
             set(
-                Stockist.objects.filter(end_date__lt=timezone.now())
+                Stockist.objects.filter(end_date__lt=today)
                 .values_list(
                     'end_date__year',
                     flat=True

--- a/app/pages/views.py
+++ b/app/pages/views.py
@@ -10,7 +10,7 @@ def about(request):
 def stockists(request):
     context = {
         'current_stockists': Stockist.objects.filter(
-            end_date__gte=timezone.now()).order_by('-end_date'),
+            end_date__gte=timezone.now()).order_by('start_date'),
         'past_stockists': Stockist.objects.filter(
             end_date__lt=timezone.now()).order_by('-end_date'),
         'venues': Venue.objects.all().order_by('name'),


### PR DESCRIPTION
Updates site content and stockists ordering to better reflect current exhibitions and guide users to the stockists page.

Changes:

- Reorders “current stockists” query to sort by start_date.
- Updates About page copy and formatting.
- Adds a homepage call-to-action linking to the Stockists page.